### PR TITLE
Added List type to support subdocuments

### DIFF
--- a/fields/types/list/ListColumn.js
+++ b/fields/types/list/ListColumn.js
@@ -3,30 +3,26 @@ import ItemsTableCell from '../../components/ItemsTableCell';
 import ItemsTableValue from '../../components/ItemsTableValue';
 import { plural } from '../../../admin/client/utils/string';
 
-var ListColumn = React.createClass({
-	displayName: 'ListColumn',
-	propTypes: {
+export default class ListColumn extends React.Component {
+	displayName: 'ListColumn'
+	props: {
 		col: React.PropTypes.object,
 		data: React.PropTypes.object,
-	},
+	}
+
 	getValue () {
 		var value = this.props.data.fields[this.props.col.path];
-		if (Array.isArray(value)) {
-			return plural(value.length, '* Value', '* Values');
-		} else {
-			return '';
-		}
-	},
+		return Array.isArray(value) ? plural(value.length, '* Value', '* Values') : ''
+	}
+
 	render () {
-		const value = this.getValue();
+		const value = this.getValue()
 		return (
 			<ItemsTableCell>
-			<ItemsTableValue padded interior field={this.props.col.type}>
-		{value}
-	</ItemsTableValue>
-		</ItemsTableCell>
-	);
-	},
-});
-
-module.exports = ListColumn;
+				<ItemsTableValue padded interior field={this.props.col.type}>
+					{value}
+				</ItemsTableValue>
+			</ItemsTableCell>
+		)
+	}
+};

--- a/fields/types/list/ListColumn.js
+++ b/fields/types/list/ListColumn.js
@@ -11,7 +11,7 @@ export default class ListColumn extends React.Component {
 	}
 
 	getValue () {
-		var value = this.props.data.fields[this.props.col.path];
+		let value = this.props.data.fields[this.props.col.path];
 		return Array.isArray(value) ? plural(value.length, '* Value', '* Values') : ''
 	}
 

--- a/fields/types/list/ListColumn.js
+++ b/fields/types/list/ListColumn.js
@@ -11,7 +11,7 @@ export default class ListColumn extends React.Component {
 	}
 
 	getValue () {
-		let value = this.props.data.fields[this.props.col.path];
+		const value = this.props.data.fields[this.props.col.path];
 		return Array.isArray(value) ? plural(value.length, '* Value', '* Values') : ''
 	}
 

--- a/fields/types/list/ListColumn.js
+++ b/fields/types/list/ListColumn.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import ItemsTableCell from '../../components/ItemsTableCell';
+import ItemsTableValue from '../../components/ItemsTableValue';
+import { plural } from '../../../admin/client/utils/string';
+
+var ListColumn = React.createClass({
+	displayName: 'ListColumn',
+	propTypes: {
+		col: React.PropTypes.object,
+		data: React.PropTypes.object,
+	},
+	getValue () {
+		var value = this.props.data.fields[this.props.col.path];
+		if (Array.isArray(value)) {
+			return plural(value.length, '* Value', '* Values');
+		} else {
+			return '';
+		}
+	},
+	render () {
+		const value = this.getValue();
+		return (
+			<ItemsTableCell>
+			<ItemsTableValue padded interior field={this.props.col.type}>
+		{value}
+	</ItemsTableValue>
+		</ItemsTableCell>
+	);
+	},
+});
+
+module.exports = ListColumn;

--- a/fields/types/list/ListField.js
+++ b/fields/types/list/ListField.js
@@ -1,0 +1,132 @@
+/* eslint-disable react/jsx-no-bind */
+
+import assign from 'object-assign';
+import React from 'react';
+import Field from '../Field';
+import Domify from 'react-domify';
+
+import { Fields } from 'FieldTypes';
+import { Button, GlyphButton } from '../../../admin/client/App/elemental';
+import InvalidFieldType from '../../../admin/client/App/shared/InvalidFieldType';
+
+let i = 0;
+function generateId () {
+	return i++;
+};
+
+const ItemDom = ({ name, id, onRemove, children }) => (
+	<div style={{
+		borderTop: '2px solid #eee',
+		paddingTop: 15,
+	}}>
+		{name && <input type="hidden" name={name} value={id}/>}
+		{children}
+		<div style={{ textAlign: 'right', paddingBottom: 10 }}>
+			<Button size="xsmall" color="danger" onClick={onRemove}>
+				remove
+			</Button>
+		</div>
+	</div>
+);
+
+module.exports = Field.create({
+	displayName: 'ListField',
+	statics: {
+		type: 'List',
+	},
+	propTypes: {
+		fields: React.PropTypes.object.isRequired,
+		label: React.PropTypes.string,
+		onChange: React.PropTypes.func.isRequired,
+		path: React.PropTypes.string.isRequired,
+		value: React.PropTypes.array,
+	},
+	addItem () {
+		const { path, value, onChange } = this.props;
+		onChange({
+			path,
+			value: [
+				...value,
+				{
+					id: generateId(),
+					_isNew: true,
+				},
+			],
+		});
+	},
+	removeItem (index) {
+		const { value: oldValue, path, onChange } = this.props;
+		const value = oldValue.slice(0, index).concat(oldValue.slice(index + 1));
+		onChange({ path, value });
+	},
+	handleFieldChange (index, event) {
+		const { value: oldValue, path, onChange } = this.props;
+		const head = oldValue.slice(0, index);
+		const item = {
+			...oldValue[index],
+			[event.path]: event.value,
+		};
+		const tail = oldValue.slice(index + 1);
+		const value = [...head, item, ...tail];
+		onChange({ path, value });
+	},
+	renderFieldsForItem (index, value) {
+		return Object.keys(this.props.fields).map((path) => {
+			const field = this.props.fields[path];
+			if (typeof Fields[field.type] !== 'function') {
+				return React.createElement(InvalidFieldType, { type: field.type, path: field.path, key: field.path });
+			}
+			const props = assign({}, field);
+			props.value = value[field.path];
+			props.values = value;
+			props.onChange = this.handleFieldChange.bind(this, index);
+			props.mode = 'edit';
+			props.inputNamePrefix = `${this.props.path}[${index}]`;
+			props.key = field.path;
+			// TODO ?
+			// if (props.dependsOn) {
+			// 	props.currentDependencies = {};
+			// 	Object.keys(props.dependsOn).forEach(dep => {
+			// 		props.currentDependencies[dep] = this.state.values[dep];
+			// 	});
+			// }
+			return React.createElement(Fields[field.type], props);
+		}, this);
+	},
+	renderItems () {
+		const { value = [], path } = this.props;
+		const onAdd = this.addItem;
+		return (
+			<div>
+				{value.map((value, index) => {
+					const { id, _isNew } = value;
+					const name = !_isNew && `${path}[${index}][id]`;
+					const onRemove = e => this.removeItem(index);
+
+					return (
+						<ItemDom key={id} {...{ id, name, onRemove }}>
+							{this.renderFieldsForItem(index, value)}
+						</ItemDom>
+					);
+				})}
+				<GlyphButton color="success" glyph="plus" position="left" onClick={onAdd}>
+					Add
+				</GlyphButton>
+			</div>
+		);
+	},
+	renderUI () {
+		const { label, value } = this.props;
+		return (
+			<div>
+				<h3 data-things="whatever">{label}</h3>
+				{this.shouldRenderField() ? (
+					this.renderItems()
+				) : (
+					<Domify value={value} />
+				)}
+				{this.renderNote()}
+			</div>
+		);
+	},
+});

--- a/fields/types/list/ListFilter.js
+++ b/fields/types/list/ListFilter.js
@@ -1,0 +1,43 @@
+/*
+ TODO: Not sure what this should look like yet,
+ it's currently basically a copy of the Boolean filter
+ so that the Admin UI builds successfully
+ */
+
+import React from 'react';
+import { SegmentedControl } from 'elemental';
+
+const VALUE_OPTIONS = [
+	{ label: 'Has Values', value: true },
+	{ label: 'Is Empty', value: false },
+];
+
+function getDefaultValue () {
+	return {
+		value: true,
+	};
+}
+
+var ListFilter = React.createClass({
+	propTypes: {
+		filter: React.PropTypes.shape({
+			value: React.PropTypes.bool,
+		}),
+	},
+	statics: {
+		getDefaultValue: getDefaultValue,
+	},
+	getDefaultProps () {
+		return {
+			filter: getDefaultValue(),
+		};
+	},
+	updateValue (value) {
+		this.props.onChange({ value });
+	},
+	render () {
+		return <SegmentedControl equalWidthSegments options={VALUE_OPTIONS} value={this.props.filter.value} onChange={this.updateValue} />;
+	},
+});
+
+module.exports = ListFilter;

--- a/fields/types/list/ListType.js
+++ b/fields/types/list/ListType.js
@@ -1,0 +1,225 @@
+var async = require('async');
+var FieldType = require('../Type');
+var util = require('util');
+var utils = require('keystone-utils');
+
+var isReserved = require('../../../lib/list/isReserved');
+
+/**
+ * List FieldType Constructor
+ * @extends Field
+ * @api public
+ */
+function list (keystoneList, path, options) {
+	this._underscoreMethods = ['format'];
+	list.super_.call(this, keystoneList, path, options);
+}
+list.properName = 'List';
+util.inherits(list, FieldType);
+
+function validateFieldType (field, path, type) {
+	var Field = field.list.keystone.Field;
+	if (!(type.prototype instanceof Field)) {
+		// Convert native field types to their default Keystone counterpart
+		if (type === String) {
+			type = Field.Types.Text;
+		} else if (type === Number) {
+			type = Field.Types.Number;
+		} else if (type === Boolean) {
+			type = Field.Types.Boolean;
+		} else if (type === Date) {
+			type = Field.Types.Datetime;
+		} else {
+			throw new Error(
+				'Unrecognised field constructor for nested schema path `' + path
+				+ '` in `' + field.list.key + '.' + field.path + '`: ' + type
+			);
+		}
+	}
+	return type;
+}
+
+/**
+ * Registers the field on the List's Mongoose Schema.
+ *
+ * @api public
+ */
+list.prototype.addToSchema = function (schema) {
+	var field = this;
+	var mongoose = this.list.keystone.mongoose;
+
+	var fields = this.fields = {};
+	var fieldsArray = this.fieldsArray = [];
+	var fieldsSpec = this.options.fields;
+	var itemSchema = new mongoose.Schema();
+
+	if (typeof fieldsSpec !== 'object' || !Object.keys(fieldsSpec).length) {
+		throw new Error(
+			'List field ' + field.list.key + '.' + field.path
+			+ ' must be configured with `fields`.'
+		);
+	}
+
+	function createField (path, options) {
+		if (typeof options === 'function') {
+			options = { type: options };
+		}
+		if (field.list.get('noedit') || field.noedit) {
+			options.noedit = true;
+		}
+		if (typeof options.type !== 'function') {
+			throw new Error(
+				'Invalid type for nested schema path `' + path + '` in `'
+				+ field.list.key + '.' + field.path + '`.\n'
+				+ 'Did you misspell the field type?\n'
+			);
+		}
+		options.type = validateFieldType(field, path, options.type);
+		// We need to tell the Keystone List that this field type is in use
+		field.list.fieldTypes[options.type.name] = options.type.properName;
+		// WYSIWYG HTML fields are special-cased
+		if (options.type.name === 'html' && options.wysiwyg) {
+			field.list.fieldTypes.wysiwyg = true;
+		}
+		// Tell the Field that it is nested, this changes the constructor slightly
+		options._isNested = true;
+		options._nestedSchema = itemSchema;
+		return new options.type(field.list, path, options);
+	}
+
+	Object.keys(fieldsSpec).forEach(function (path) {
+		if (!fieldsSpec[path]) {
+			throw new Error(
+				'Invalid value for nested schema path `' + path + '` in `'
+				+ field.list.key + '.' + field.path + '`.\n'
+				+ 'Did you misspell the field type?\n'
+			);
+		}
+		if (isReserved(path)) {
+			throw new Error(
+				'Nested schema path ' + path + ' on field '
+				+ field.list.key + '.' + field.path + ' is a reserved path'
+			);
+		}
+		var newField = createField(path, fieldsSpec[path]);
+		fields[path] = newField;
+		fieldsArray.push(newField);
+	});
+
+	if (this.options.decorateSchema) {
+		this.options.decorateSchema(itemSchema);
+	}
+
+	schema.add(this._path.addTo({}, [itemSchema]));
+	this.bindUnderscoreMethods();
+};
+
+/**
+ * Provides additional properties for the Admin UI
+ */
+list.prototype.getProperties = function (item, separator) {
+	var fields = {};
+	this.fieldsArray.forEach(function (field) {
+		fields[field.path] = field.getOptions();
+	});
+	return {
+		fields: fields,
+	};
+};
+
+/**
+ * Formats the field value
+ */
+list.prototype.format = function (item, separator) {
+	// TODO: How should we format nested items? Returning length for now.
+	var items = item.get(this.path) || [];
+	return utils.plural(items.length, '* Value', '* Values');
+};
+
+// TODO: How should we filter list values?
+/*
+ list.prototype.addFilterToQuery = function (filter) { };
+ */
+
+/**
+ * Asynchronously confirms that the provided value is valid
+ */
+list.prototype.validateInput = function (data, callback) {
+	// TODO
+	// var value = this.getValueFromData(data);
+	var result = true;
+	utils.defer(callback, result);
+};
+
+/**
+ * Asynchronously confirms that the a value is present
+ */
+list.prototype.validateRequiredInput = function (item, data, callback) {
+	// TODO
+	// var value = this.getValueFromData(data);
+	var result = true;
+	utils.defer(callback, result);
+};
+
+list.prototype.getData = function (item) {
+	var items = item.get(this.path);
+	var fieldsArray = this.fieldsArray;
+	return items.map(function (i) {
+		var result = { id: i.id };
+		for (var field of fieldsArray) {
+			result[field.path] = field.getData(i);
+		}
+		return result;
+	});
+};
+
+/**
+ * Updates the value for this field in the item from a data object.
+ * If the data object does not contain the value, then the value is set to empty array.
+ */
+list.prototype.updateItem = function (item, data, files, callback) {
+	if (typeof files === 'function') {
+		callback = files;
+		files = {};
+	}
+
+	var field = this;
+	var values = this.getValueFromData(data);
+	// Don't update the value when it is undefined
+	if (values === undefined) {
+		return utils.defer(callback);
+	}
+	// Reset the value when null or an empty string is provided
+	if (values === null || values === '') {
+		values = [];
+	}
+	// Wrap non-array values in an array
+	if (!Array.isArray(values)) {
+		values = [values];
+	}
+	// NOTE - this method will overwrite the entire array, which is less specific
+	// than it could be. Concurrent saves could lead to race conditions, but we
+	// can make it more clever in a future release; this is otherwise the most
+	// resiliant update method that can be implemented without a lot of complexity
+	var listArray = item.get(this.path);
+	async.map(values, function (value, next) {
+		var prevItem = listArray.id(value.id);
+		var newItem = listArray.create(prevItem);
+		async.forEach(field.fieldsArray, function (nestedField, done) {
+			if (nestedField.updateItem.length === 4) {
+				nestedField.updateItem(newItem, value, files, done);
+			} else {
+				nestedField.updateItem(newItem, value, done);
+			}
+		}, function (err) {
+			next(err, newItem);
+		});
+	}, function (err, updatedValues) {
+		if (err) return callback(err);
+		item.set(field.path, updatedValues);
+		callback();
+	});
+};
+
+/* Export Field Type */
+module.exports = list;

--- a/lib/fieldTypes.js
+++ b/lib/fieldTypes.js
@@ -14,6 +14,7 @@ var fields = {
 	get GeoPoint () { return require('../fields/types/geopoint/GeoPointType'); },
 	get Html () { return require('../fields/types/html/HtmlType'); },
 	get Key () { return require('../fields/types/key/KeyType'); },
+	get List () { return require('../fields/types/list/ListType'); },
 	get LocalFile () { return require('../fields/types/localfile/LocalFileType'); },
 	get LocalFiles () { return require('../fields/types/localfiles/LocalFilesType'); },
 	get Location () { return require('../fields/types/location/LocationType'); },


### PR DESCRIPTION
This PR adds support for subdocuments in keystone

GUI needs more work, but is out of scope of my project

Example of how this should be implemented : 

```
employees: {type: Types.List, fields: {
    userID: {type: Types.Relationship, ref: 'User', initial: true},
    specialHours: {type: Types.List, fields: {
      start: {type: Types.Datetime},
      end: {type: Types.Datetime},
    }},
    specialDays: {type: Types.List, fields: {
      monday: {type: Types.Boolean},
      tuesday: {type: Types.Boolean},
      wednesday: {type: Types.Boolean},
      thursday: {type: Types.Boolean},
      friday: {type: Types.Boolean},
      saturday: {type: Types.Boolean},
      sunday: {type: Types.Boolean}
    }}
  }}
```
